### PR TITLE
Exclude vendor dir from Jekyll build process.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -84,6 +84,7 @@ exclude:
   - Makefile
   - bin/
   - .Rproj.user/
+  - vendor
 
 # Turn on built-in syntax highlighting.
 highlighter: rouge


### PR DESCRIPTION
Without this the site can't be built using 'bundle exec jekyll build'
("Document 'vendor/bundle/ruby/2.5.0/gems/jekyll-3.8.5/lib/site_template/_posts/0000-00-00-welcome-to-jekyll.markdown.erb'
 does not have a valid date in the YAML front matter.")
---