### PR TITLE
update gitignore and improve project organization exercise

### DIFF
--- a/_episodes/02-project-setup.md
+++ b/_episodes/02-project-setup.md
@@ -95,9 +95,6 @@ touch README.md
 ~~~
 {: .language-bash}
 
-We will also have a `.gitignore` file and some files and folders that are not included. In general data is ignored,
-but scripts that download or process the data in some way, are good to keep. Results should be ignored.
-
 > ## Exercise
 >
 > Make each of the following files in the project in the correct location by
@@ -126,6 +123,39 @@ replacing the `__` on each line
 > > {: .language-bash }
 > {: .solution }
 {: .challenge}
+
+> ## Where to store results?
+> A question that we may ask ourselves is where to store our __results__, that is, our final, processed data. This is
+> debatable, and depends on the characteristics of our project. If we have many intermediate files between our
+> raw data and final results, it may be interesting to create a `results/` directory. If we only have a couple of 
+> intermediate files, we could simply store our results in the `data/` directory. If we generate many figures from
+> our data, we could create a directory called `figures/` or `img/`. 
+{: .callout}
+
+## Configuration files and `.gitignore`
+The root of the project, _i.e._ the `project` folder containing all of our subdirectories, may also contain
+configuration files from various applications. Some types of configuration files include:
+- `.editorconfig`, that interacts with text editors and IDEs;
+- `.yml` files that provide settings for web services (such as [GitHub Actions](https://docs.github.com/en/actions));
+- the `.gitignore` file, that specificies which files should be __ignored__ by Git version control.
+
+The `.gitignore` is particularly useful if we have large data files, and don't want them to be attached to our package
+distribution. To address this, we should include instructions or scripts to download the data. Results should also be
+ignored. For our example project, we could create a `.gitignore` file:
+
+```bash
+touch .gitignore
+```
+
+And add the following content to it:
+```none
+data/*.csv
+```
+
+This would ignore the `data/raw_data.csv` file, preventing from adding it to version control. This can be very important
+depending on the size of our data! We don't want the user to have to download very large files along with our repository,
+and it may even cause problems with hosting services. If a `results/` subdirectory was created, we should also add
+that to the `.gitignore` file.
 
 > ## Exercise
 >

--- a/_episodes/02-project-setup.md
+++ b/_episodes/02-project-setup.md
@@ -90,6 +90,7 @@ mkdir data
 mkdir docs
 mkdir experiments
 mkdir package
+mkdir results
 touch setup.py
 touch README.md
 ~~~
@@ -98,7 +99,7 @@ touch README.md
 We will also have a `.gitignore` file and some files and folders that are not included. In general data is ignored,
 but scripts that download or process the data in some way, are good to keep. Results should be ignored.
 
-> ## Exercise
+> ## Creating project files
 >
 > Make each of the following files in the project in the correct location by
 replacing the `__` on each line
@@ -110,6 +111,7 @@ replacing the `__` on each line
 > touch __/reproduce_paper.py # code to re-run the analyses reported in your methods paper about the package
 > touch __/helper_functions.py # auxilliary functions for routine tasks associated with the novel method
 > touch __/how_to_setup.md # details to help others prepare equivalent experiments to those presented in your paper
+> touch __/.gitignore # flags files that should be ignored by version control, such as big data files
 > ~~~
 > {: .language-bash}
 >
@@ -122,8 +124,18 @@ replacing the `__` on each line
 > > touch experiments/reproduce_paper.py
 > > touch package/helper_functions.py
 > > touch docs/how_to_setup.md
+> > touch ./.gitignore
 > > ~~~
 > > {: .language-bash }
+> > The `.gitignore` file could contain, for example, this line:
+> > ```
+> > data/*.csv
+> > results/*
+> > ```
+> > {: .language-none}
+> > Which would prevent `data/raw_data.csv` and any files in the `results/` directory from being included in version
+> > control. This is fairly common when working with very large files, and can be addressed by adding instructions on
+> > how to download the data.
 > {: .solution }
 {: .challenge}
 


### PR DESCRIPTION
Hi,

This is related to #55.

Summary of changes:
  - Renames challenge from 'Exercise' to 'Creating project files'.
  - Adds 'mkdir results' command.
  - Improves explanation of .gitignore.

Best,
Vini